### PR TITLE
Fix ESM config for frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "food-truck-fleet-frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- enable Node ESM mode for the frontend to allow `postcss.config.js` to use `export` syntax

## Testing
- `npm -C frontend run build` *(fails: `vite` not found)*
- `npm -C frontend install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688626ebf8e08324aa7519a79cf26879